### PR TITLE
Relax the omniauth-oauth2 dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,9 +1,9 @@
 PATH
   remote: .
   specs:
-    omniauth-pinterest (2.0.3)
+    omniauth-pinterest (2.0.4)
       omniauth (~> 1.0)
-      omniauth-oauth2 (~> 1.6.0)
+      omniauth-oauth2 (~> 1.6)
 
 GEM
   remote: http://rubygems.org/

--- a/lib/omniauth-pinterest/version.rb
+++ b/lib/omniauth-pinterest/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Pinterest
-    VERSION = '2.0.3'
+    VERSION = '2.0.4'
   end
 end

--- a/omniauth-pinterest.gemspec
+++ b/omniauth-pinterest.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::Pinterest::VERSION
 
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.6.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.6'
 
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test', '~> 0.6.3'


### PR DESCRIPTION
It doesn’t need to be this strict, it should work with any 1.X version of omniauth-oauth2.